### PR TITLE
Add Build Version Info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(MoniqueMonosynth VERSION 1.2.0 LANGUAGES C CXX ASM)
 
 # cmake options
 option(MONIQUE_COPY_PLUGIN_AFTER_BUILD "Copy JUCE Plugins after built" OFF)
+option(MONIQUE_RELIABLE_VERSION_INFO "Update version info on every build (off: generate only at configuration time)" ON)
 
 # Set ourselves up for fpic C++17 all platforms
 set(CMAKE_CXX_STANDARD 17)
@@ -17,17 +18,17 @@ add_subdirectory(libs/JUCE)
 
 juce_add_plugin(MoniqueMonosynth
         VERSION "1.2"
-        BUNDLE_ID "com.monoplugs.monique"
-        COMPANY_NAME "Monoplugs"
-        COMPANY_COPYRIGHT "Monoplugs 2021"
-        COMPANY_WEBSITE "http://monique.monoplugs.com"
-        COMPANY_EMAIL "info@monoplugs.com"
+        BUNDLE_ID "org.surge-synth-team.monique"
+        COMPANY_NAME "Surge Synth Team"
+        PLUGIN_MANUFACTURER_CODE "VmbA"
+        COMPANY_COPYRIGHT "Copyright Thomas Arndt and Authors in Github, 2018-2021"
+        COMPANY_WEBSITE "http://surge-synth-team.org"
 
         FORMATS VST3 AU Standalone
 
         PLUGIN_NAME "Monique"
         DESCRIPTION "Monophonic Unique Synthesizer"
-        PLUGIN_MANUFACTURER_CODE "MoPl"
+
         PLUGIN_CODE "moni"
         AAX_IDENTIFIER "com.monoplugs.monique-synthesizer"
         AU_EXPORT_PREFIX "moniAU"
@@ -35,9 +36,9 @@ juce_add_plugin(MoniqueMonosynth
         COPY_PLUGIN_AFTER_BUILD ${MONIQUE_COPY_PLUGIN_AFTER_BUILD}
 )
 
-juce_generate_juce_header(MoniqueMonosynth)
+juce_generate_juce_header(${PROJECT_NAME})
 
-target_compile_definitions(MoniqueMonosynth
+target_compile_definitions(${PROJECT_NAME}
   PUBLIC
         DROWAUDIO_USE_CURL=disabled
         JUCE_ALSA=1
@@ -60,7 +61,7 @@ target_compile_definitions(MoniqueMonosynth
         IS_PLUGIN=1
 )
 
-target_sources(MoniqueMonosynth
+target_sources(${PROJECT_NAME}
   PRIVATE
     Source/monique_core_Datastructures.cpp
     Source/monique_core_Parameters.cpp
@@ -90,7 +91,7 @@ target_sources(MoniqueMonosynth
 
 if (APPLE OR UNIX)
     # these all need fixing obviously
-    target_compile_options(MoniqueMonosynth PUBLIC
+    target_compile_options(${PROJECT_NAME} PUBLIC
             -Wno-deprecated-declarations
             -Wno-float-conversion
             -Wno-sign-conversion
@@ -110,7 +111,7 @@ juce_add_binary_data(MoniqueMonosynth_BinaryData
     Icon/monique_desktop_icon_1024x1024.png
 )
 
-target_link_libraries(MoniqueMonosynth
+target_link_libraries(${PROJECT_NAME}
   PRIVATE
     MoniqueMonosynth_BinaryData
     juce::juce_audio_basics
@@ -131,3 +132,27 @@ target_link_libraries(MoniqueMonosynth
     juce::juce_recommended_lto_flags
     juce::juce_recommended_warning_flags
 )
+
+
+# version generation
+if(MONIQUE_RELIABLE_VERSION_INFO)
+    add_custom_target(version-info BYPRODUCTS ${CMAKE_BINARY_DIR}/geninclude/version.cpp
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${CMAKE_COMMAND} -D CMAKE_PROJECT_VERSION_MAJOR=${CMAKE_PROJECT_VERSION_MAJOR}
+            -D CMAKE_PROJECT_VERSION_MINOR=${CMAKE_PROJECT_VERSION_MINOR}
+            -D MONIQUESRC=${CMAKE_SOURCE_DIR} -D MONIQUEBLD=${CMAKE_BINARY_DIR}
+            -D AZURE_PIPELINE=${AZURE_PIPELINE}
+            -D WIN32=${WIN32}
+            -D CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+            -D CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}
+            -D CMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION}
+            -P ${CMAKE_SOURCE_DIR}/cmake/versiontools.cmake
+            )
+    add_dependencies(${PROJECT_NAME} version-info)
+else()
+    set(MONIQUESRC ${CMAKE_SOURCE_DIR})
+    set(MONIQUEBLD ${CMAKE_BINARY_DIR})
+    include(${CMAKE_SOURCE_DIR}/cmake/versiontools.cmake)
+endif()
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source)
+target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/geninclude/version.cpp)

--- a/Source/monique_core_Processor.cpp
+++ b/Source/monique_core_Processor.cpp
@@ -8,6 +8,7 @@
 #include "monique_ui_Refresher.h"
 #include "monique_ui_AmpPainter.h"
 #include "monique_ui_LookAndFeel.h"
+#include "version.h"
 
 
 //==============================================================================
@@ -245,6 +246,7 @@ mono_AudioDeviceManager( new RuntimeNotifyer() ),
 #endif
 #ifdef JUCE_DEBUG
     std::cout << "MONIQUE: init core" << std::endl;
+    std::cout << "MONIQUE: version - " << Monique::Build::FullVersionStr << " built at " << Monique::Build::BuildDate << " " << Monique::Build::BuildTime << std::endl;
 #endif
     {
         ui_look_and_feel = new UiLookAndFeel();

--- a/Source/monique_ui_Credits.cpp
+++ b/Source/monique_ui_Credits.cpp
@@ -21,6 +21,7 @@
 //[/Headers]
 
 #include "monique_ui_Credits.h"
+#include "version.h"
 
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
@@ -303,6 +304,10 @@ void monique_ui_Credits::paint (Graphics& g)
                                RectanglePlacement::centred, 1.000f);
 
     //[UserPaint] Add your own custom painting code here..
+    auto r = getLocalBounds().withTrimmedTop(getLocalBounds().getHeight() - 14).translated(0, -5);
+    g.setColour(juce::Colours::lightgrey);
+    g.setFont(12);
+    g.drawText( std::string("Version: " ) + Monique::Build::FullVersionStr + " Built: " + Monique::Build::BuildDate + " " + Monique::Build::BuildTime, r, juce::Justification::centred);
     //[/UserPaint]
 }
 

--- a/Source/version.cpp.in
+++ b/Source/version.cpp.in
@@ -1,0 +1,37 @@
+/*
+** This file is rebuilt and substitited every time you run a build.
+** Things which need to be per-build should be defined here, declared
+** in the version.h header, and then used wherever you want
+*/
+#include "version.h"
+
+namespace Monique
+{
+   const char* Build::MajorVersionStr = "@MONIQUE_MAJOR_VERSION@";
+   const int   Build::MajorVersionInt = @MONIQUE_MAJOR_VERSION@;
+   
+   const char* Build::SubVersionStr = "@MONIQUE_SUB_VERSION@";
+   const int   Build::SubVersionInt = @MONIQUE_SUB_VERSION@;
+   
+   const char* Build::ReleaseNumberStr = "@MONIQUE_RELEASE_NUMBER@";
+   const char* Build::ReleaseStr = "@MONIQUE_RELEASE_VERSION@";
+   
+   const char* Build::BuildNumberStr = "@MONIQUE_BUILD_HASH@"; // Build number to be sure that each result could identified.
+   
+   const char* Build::FullVersionStr = "@MONIQUE_FULL_VERSION@";
+   const char* Build::BuildHost = "@MONIQUE_BUILD_FQDN@";
+   const char* Build::BuildArch = "@MONIQUE_BUILD_ARCH@";
+   const char *Build::BuildCompiler = "@CMAKE_CXX_COMPILER_ID@-@CMAKE_CXX_COMPILER_VERSION@";
+
+   const char* Build::BuildLocation = "@MONIQUE_BUILD_LOCATION@";
+
+   const char* Build::BuildDate = "@MONIQUE_BUILD_DATE@";
+   const char* Build::BuildTime = "@MONIQUE_BUILD_TIME@";
+   const char* Build::BuildYear = "@MONIQUE_BUILD_YEAR@";
+
+   const char* Build::GitHash = "@GIT_COMMIT_HASH@";
+   const char* Build::GitBranch = "@GIT_BRANCH@";
+
+   const char* Build::CMAKE_INSTALL_PREFIX = "@CMAKE_INSTALL_PREFIX@";
+}
+

--- a/Source/version.h
+++ b/Source/version.h
@@ -1,0 +1,38 @@
+#ifndef __version__
+#define __version__
+
+namespace Monique
+{
+struct Build
+{
+    static const char *MajorVersionStr;
+    static const int MajorVersionInt;
+
+    static const char *SubVersionStr;
+    static const int SubVersionInt;
+
+    static const char *ReleaseNumberStr;
+    static const char *ReleaseStr;
+
+    static const char *GitHash;
+    static const char *GitBranch;
+
+    static const char *BuildNumberStr;
+
+    static const char *FullVersionStr;
+    static const char *BuildHost;
+    static const char *BuildArch;
+    static const char *BuildCompiler;
+
+    static const char *BuildLocation; // Local or Pipeline
+
+    static const char *BuildDate;
+    static const char *BuildTime;
+    static const char *BuildYear;
+
+    // Some features from cmake
+    static const char *CMAKE_INSTALL_PREFIX;
+};
+} // namespace Surge
+
+#endif //__version__

--- a/cmake/versiontools.cmake
+++ b/cmake/versiontools.cmake
@@ -1,0 +1,118 @@
+
+find_package(Git)
+
+if (EXISTS ${MONIQUESRC}/VERSION_GIT_INFO)
+    message(STATUS "VERSION_GIT_INFO file is present; using that rather than git query")
+    # Line 2 is the branch, line 3 is the hash
+    execute_process(
+            COMMAND sed -n "2p" ${MONIQUESRC}/VERSION_GIT_INFO
+            WORKING_DIRECTORY ${MONIQUESRC}
+            OUTPUT_VARIABLE GIT_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    execute_process(
+            COMMAND sed -n "3p" ${MONIQUESRC}/VERSION_GIT_INFO
+            WORKING_DIRECTORY ${MONIQUESRC}
+            OUTPUT_VARIABLE GIT_COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+elseif (Git_FOUND)
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+            WORKING_DIRECTORY ${MONIQUESRC}
+            OUTPUT_VARIABLE GIT_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            WORKING_DIRECTORY ${MONIQUESRC}
+            OUTPUT_VARIABLE GIT_COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif ()
+
+if ("${GIT_BRANCH}" STREQUAL "")
+    message(WARNING "Could not determine Git branch, using placeholder.")
+    set(GIT_BRANCH "git-no-branch")
+endif ()
+if ("${GIT_COMMIT_HASH}" STREQUAL "")
+    message(WARNING "Could not determine Git commit hash, using placeholder.")
+    set(GIT_COMMIT_HASH "git-no-commit")
+endif ()
+
+if (WIN32)
+    set(MONIQUE_BUILD_ARCH "x86")
+else ()
+    execute_process(
+            COMMAND uname -m
+            OUTPUT_VARIABLE MONIQUE_BUILD_ARCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif ()
+
+cmake_host_system_information(RESULT MONIQUE_BUILD_FQDN QUERY FQDN)
+
+message(STATUS "Setting up surge version")
+message(STATUS "  git hash is ${GIT_COMMIT_HASH} and branch is ${GIT_BRANCH}")
+message(STATUS "  buildhost is ${MONIQUE_BUILD_FQDN}")
+message(STATUS "  buildarch is ${MONIQUE_BUILD_ARCH}")
+
+if (${AZURE_PIPELINE})
+    message(STATUS "Azure Pipeline Build")
+    set(lpipeline "pipeline")
+else ()
+    message(STATUS "Developer Local Build")
+    set(lpipeline "local")
+endif ()
+
+if (${GIT_BRANCH} STREQUAL "main")
+    if (${AZURE_PIPELINE})
+        set(lverpatch "nightly")
+    else ()
+        set(lverpatch "main")
+    endif ()
+    set(lverrel "999")
+    set(fverpatch ${lverpatch})
+else ()
+    string(FIND ${GIT_BRANCH} "release/" RLOC)
+    if (${RLOC} EQUAL 0)
+        message(STATUS "Configuring a Release Build from '${GIT_BRANCH}'")
+        string(SUBSTRING ${GIT_BRANCH} 13 100 RV) # that's release-xt slash 1.7.
+        string(FIND ${RV} "." DLOC)
+        if (NOT (DLOC EQUAL -1))
+            math(EXPR DLP1 "${DLOC} + 1")
+            string(SUBSTRING ${RV} ${DLP1} 100 LRV) # skip that first dots
+            set(lverrel ${LRV})
+        else ()
+            set(lverrel "99")
+        endif ()
+        set(lverpatch "stable-${lverrel}")
+        set(fverpatch "${lverrel}")
+    else ()
+        set(lverpatch ${GIT_BRANCH})
+        set(fverpatch ${lverpatch})
+        set(lverrel "1000")
+    endif ()
+endif ()
+
+set(MONIQUE_FULL_VERSION "${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${fverpatch}.${GIT_COMMIT_HASH}")
+set(MONIQUE_MAJOR_VERSION "${CMAKE_PROJECT_VERSION_MAJOR}")
+set(MONIQUE_SUB_VERSION "${CMAKE_PROJECT_VERSION_MINOR}")
+set(MONIQUE_RELEASE_VERSION "${lverpatch}")
+set(MONIQUE_RELEASE_NUMBER "${lverrel}")
+set(MONIQUE_BUILD_HASH "${GIT_COMMIT_HASH}")
+set(MONIQUE_BUILD_LOCATION "${lpipeline}")
+
+string(TIMESTAMP MONIQUE_BUILD_DATE "%Y-%m-%d")
+string(TIMESTAMP MONIQUE_BUILD_YEAR "%Y")
+string(TIMESTAMP MONIQUE_BUILD_TIME "%H:%M:%S")
+
+message(STATUS "Using MONIQUE_VERSION=${MONIQUE_FULL_VERSION}")
+
+message(STATUS "Configuring ${MONIQUEBLD}/geninclude/version.cpp")
+configure_file(${MONIQUESRC}/Source/version.cpp.in
+        ${MONIQUEBLD}/geninclude/version.cpp)
+


### PR DESCRIPTION
1. Port the surge build info to Monique
2. Use that to put a small version tag on the credits screen
3. Use that to print the version info on debug startup

Closes #14