### PR TITLE
Start of a Warnings strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ juce_add_plugin(MoniqueMonosynth
 
         FORMATS VST3 AU Standalone
 
+        IS_SYNTH TRUE
+        NEEDS_MIDI_INPUT TRUE
+        NEEDS_MIDI_OUTPUT FALSE
+        IS_MIDI_EFFECT FALSE
+
         PLUGIN_NAME "Monique"
         DESCRIPTION "Monophonic Unique Synthesizer"
 
@@ -87,20 +92,6 @@ target_sources(${PROJECT_NAME}
     Source/mono_AudioDeviceManager.cpp
 )
 
-if (APPLE OR UNIX)
-    # these all need fixing obviously
-    target_compile_options(${PROJECT_NAME} PUBLIC
-            -Wno-deprecated-declarations
-            -Wno-float-conversion
-            -Wno-sign-conversion
-            -Wno-shadow
-            )
-endif()
-
-if (WIN32)
-    target_compile_options( ${PROJECT_NAME} PUBLIC /permissive-)
-endif()
-
 juce_add_binary_data(MoniqueMonosynth_BinaryData
   SOURCES
     Files/A.zip
@@ -116,24 +107,79 @@ juce_add_binary_data(MoniqueMonosynth_BinaryData
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
     MoniqueMonosynth_BinaryData
-    juce::juce_audio_basics
-    juce::juce_audio_devices
     juce::juce_audio_formats
     juce::juce_audio_plugin_client
     juce::juce_audio_processors
     juce::juce_audio_utils
     juce::juce_core
-    juce::juce_cryptography
-    juce::juce_data_structures
-    juce::juce_events
     juce::juce_graphics
     juce::juce_gui_basics
     juce::juce_gui_extra
   PUBLIC
     juce::juce_recommended_config_flags
     juce::juce_recommended_lto_flags
-    juce::juce_recommended_warning_flags
 )
+
+
+if (APPLE)
+    # these all need fixing obviously. The strategy I've used on mac here is
+    # 1: Turn off the juce suggested warning flags
+    # 2: Turn on werror (mac only)
+    # 3: Turn off every no-blah which stops me building (and apply these on linux too)
+    #
+    # Then one by one we should document each of these and decide if we want to
+    # keep them or fix them. Most probably fix.
+    message(STATUS "Turning off a collection of legitimate compiler warnings" )
+    target_compile_options(${PROJECT_NAME} PUBLIC
+            -Werror
+            -Wno-deprecated-declarations
+            -Wno-float-conversion
+            -Wno-sign-conversion
+            -Wno-unused-value
+            -Wno-return-type
+            -Wno-literal-conversion
+            -Wno-shadow
+            -Wno-inconsistent-missing-override
+            )
+elseif(UNIX)
+    # FIXME - I should be more careful about assuming unix-not-apple == gcc
+    message(STATUS "Turning off a collection of legitimate compiler warnings" )
+    target_compile_options(${PROJECT_NAME} PUBLIC
+            -Werror
+            -Wno-deprecated-declarations
+            -Wno-float-conversion
+            -Wno-sign-conversion
+            -Wno-unused-value
+            -Wno-return-type
+            -Wno-literal-conversion
+            -Wno-shadow
+            -Wno-inconsistent-missing-override
+
+            # here's the ones we don't have on macos/clang
+            -Wno-enum-compare
+            )
+else()
+    # FIXME - and simiilarly about assuming windows == MSVC
+    message(STATUS "Turning off a collection of legitimate compiler warnings" )
+    target_compile_options(${PROJECT_NAME} PUBLIC
+            /WX # Warnings are errors
+            /W3 # and we show lots of them
+
+            # These ones need fixing for sure
+            /wd4804 # unsafe use of bool
+            /wd4805 # unsafe use of bool and float
+            /wd4715 # return values
+            /wd4996 # deprecation
+            /wd4099 # first see as struct vs class
+
+            # these ones are probably ok in our context
+            /wd4244 # double to float
+            /wd4305 # float to double
+
+            /permissive-  # allow the full spec, including 'not' and 'and keywords
+            )
+
+endif()
 
 
 # version generation

--- a/Source/monique_core_Synth.cpp
+++ b/Source/monique_core_Synth.cpp
@@ -5974,7 +5974,7 @@ void MoniqueSynthesiserVoice::start_internal( int midi_note_number_, float veloc
     }
 #endif
     // KEYTRACK OR NOTe PLAYBACK
-    const float arp_offset = pitch_offset + ( step_automation_is_on or step_automation_is_on and synth_data->arp_sequencer_data->is_sequencer and current_note != -1 ) ? arp_sequencer->get_current_tune() : 0;
+    const float arp_offset = pitch_offset + (( step_automation_is_on or step_automation_is_on and synth_data->arp_sequencer_data->is_sequencer and current_note != -1 ) ? arp_sequencer->get_current_tune() : 0);
     {
         // FIRST KEY DOWN
         const bool first_key_down_event = is_human_event_ and keys_down == 1;


### PR DESCRIPTION
This commit does a couple of things to start working through
all the warnings in the codebase

1. Turns on warnings-are-errors on all paltforms and then
2. Supresses a whole bunch of warnings, some of them rather
   legitimate, in the CMake file

This means at least a build has readable output, but also
defines the book of work we need to understake to address #16 