### PR TITLE
Add MTS-ESP Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libs/JUCE"]
 	path = libs/JUCE
 	url = https://github.com/juce-framework/JUCE
+[submodule "libs/oddsound-mts/MTS-ESP"]
+	path = libs/oddsound-mts/MTS-ESP
+	url = https://github.com/ODDSound/MTS-ESP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(libs/JUCE)
-
+add_subdirectory(libs/oddsound-mts)
 
 juce_add_plugin(MoniqueMonosynth
         VERSION "1.2"
@@ -118,6 +118,8 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
     juce::juce_recommended_config_flags
     juce::juce_recommended_lto_flags
+
+    monique::oddsound-mts
 )
 
 

--- a/Source/monique_core_Datastructures.h
+++ b/Source/monique_core_Datastructures.h
@@ -1346,6 +1346,39 @@ public:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MorphGroup)
 };
 
+class MTSClient;
+struct MoniqueTuningData
+{
+    ~MoniqueTuningData();
+
+    enum Mode {
+        TWELVE_TET,
+        SCL_KBM,
+        MTS_ESP
+    } mode{TWELVE_TET};
+    float midiNoteToFrequency(float note)
+    {
+       switch(mode)
+       {
+          case TWELVE_TET:
+             return 440.0 *  pow ( 2.0f, ((note - 69.0f) * (1.0f/12)) );
+             break;
+          case SCL_KBM:
+             // not implemented yet
+             return 440.0 *  pow ( 2.0f, ((note - 69.0f) * (1.0f/12)) );
+             break;
+          case MTS_ESP:
+             return midiNoteFromMTS(note);
+             break;
+       }
+       return 421;
+    }
+
+    MTSClient* mts_client{nullptr};
+    int mtsChecked{0};
+    void updateMTSESPStatus();
+    float midiNoteFromMTS(float note);
+};
 
 //==============================================================================
 //==============================================================================
@@ -1374,6 +1407,8 @@ struct MoniqueSynthData : ParameterListener
     const float*const sine_lookup;
     const float*const cos_lookup;
     const float*const exp_lookup;
+
+    MoniqueTuningData*const tuning;
 
     const int id;
     

--- a/Source/monique_core_Processor.cpp
+++ b/Source/monique_core_Processor.cpp
@@ -783,6 +783,11 @@ void MoniqueAudioProcessor::process ( AudioSampleBuffer& buffer_, MidiBuffer& mi
         prepareToPlay(getSampleRate(),getBlockSize());
     }
 
+    if (synth_data->tuning)
+    {
+       synth_data->tuning->updateMTSESPStatus();
+    }
+
     const int num_samples = buffer_.getNumSamples();
     buffer_.clear();
 

--- a/Source/monique_core_Synth.cpp
+++ b/Source/monique_core_Synth.cpp
@@ -1531,7 +1531,7 @@ public:
                     {
                         last_root_note = root_note;
 
-                        const float new_frequence = jmax( 5.0f, midiToFrequencyFast( root_note + freq_glide_delta*freq_glide_samples_left ) );
+                        const float new_frequence = jmax( 5.0f, synth_data->tuning->midiNoteToFrequency( root_note + freq_glide_delta*freq_glide_samples_left ) );
                         if( new_frequence != last_frequency )
                         {
                             cycle_counter.set_frequency( new_frequence );
@@ -1863,7 +1863,7 @@ public:
                         last_tune = tune;
                         last_root_note = root_note;
 
-                        const float new_frequence = jmax( 5.0f, midiToFrequencyFast( root_note + tune + freq_glide_delta*freq_glide_samples_left ) );
+                        const float new_frequence = jmax( 5.0f, synth_data->tuning->midiNoteToFrequency( root_note + tune + freq_glide_delta*freq_glide_samples_left ) );
                         if( new_frequence != last_frequency )
                         {
                             cycle_counter.set_frequency(new_frequence);
@@ -6292,7 +6292,7 @@ void MoniqueSynthesiserVoice::start_internal( int midi_note_number_, float veloc
                     // CUTOFF TRACKING 1
                     if( synth_data->keytrack_cutoff[0] )
                     {
-                        //synth_data->filter_datas[0]->cutoff.set_value( reverse_cutoff_to_slider_value( midiToFrequencyFast(note_to_use+arp_offset) ) );
+                        //synth_data->filter_datas[0]->cutoff.set_value( reverse_cutoff_to_slider_value( synth_data->tuning->midiNoteToFrequency(note_to_use+arp_offset) ) );
                     }
                     if( trigger_envelopes_ )
                     {
@@ -6468,17 +6468,17 @@ void MoniqueSynthesiserVoice::start_internal( int midi_note_number_, float veloc
             if( synth_data->keytrack_cutoff[0] )
             {
                 const int note_0 = current_note+synth_data->keytrack_cutoff_octave_offset[0]*12+arp_offset;
-                synth_data->filter_datas[0]->cutoff.set_value(reverse_cutoff_to_slider_value(midiToFrequencyFast(note_0)));
+                synth_data->filter_datas[0]->cutoff.set_value(reverse_cutoff_to_slider_value(synth_data->tuning->midiNoteToFrequency(note_0)));
             }
             if( synth_data->keytrack_cutoff[1] )
             {
                 const int note_1 = current_note+synth_data->osc_datas[1]->tune+synth_data->keytrack_cutoff_octave_offset[1]*12+arp_offset;
-                synth_data->filter_datas[1]->cutoff.set_value(reverse_cutoff_to_slider_value(midiToFrequencyFast(note_1)));
+                synth_data->filter_datas[1]->cutoff.set_value(reverse_cutoff_to_slider_value(synth_data->tuning->midiNoteToFrequency(note_1)));
             }
             if( synth_data->keytrack_cutoff[2] )
             {
                 const int note_2 = current_note+synth_data->osc_datas[2]->tune+synth_data->keytrack_cutoff_octave_offset[2]*12+arp_offset;
-                synth_data->filter_datas[2]->cutoff.set_value(reverse_cutoff_to_slider_value(midiToFrequencyFast(note_2)));
+                synth_data->filter_datas[2]->cutoff.set_value(reverse_cutoff_to_slider_value(synth_data->tuning->midiNoteToFrequency(note_2)));
             }
 		#endif 
         }

--- a/libs/oddsound-mts/CMakeLists.txt
+++ b/libs/oddsound-mts/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(oddsound-mts VERSION 0.0.0 LANGUAGES CXX)
+
+add_library(${PROJECT_NAME}
+      MTS-ESP/Client/libMTSClient.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC MTS-ESP/Client)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
+add_library(monique::${PROJECT_NAME} ALIAS ${PROJECT_NAME})


### PR DESCRIPTION
This commit binds Monique to oddsound MTS-ESP, an emerging
standard from in-daw microtuning. It is step one along the way
of adding full microtonal supprot to monique but is missing
several key things, including UI feedback of any type and
native SCL/KBM support (which requires saving state etc...).

Addresses #18