### PR TITLE
Make SHARED DeletedAtShutdown

### DIFF
--- a/Source/monique_core_Datastructures.h
+++ b/Source/monique_core_Datastructures.h
@@ -1832,7 +1832,7 @@ static inline StringRef delay_to_text( int delay_, int sample_rate_ ) noexcept
 //==============================================================================
 //==============================================================================
 //==============================================================================
-class SHARED
+class SHARED : public juce::DeletedAtShutdown
 {
 public:
     int num_instances ;
@@ -1851,6 +1851,8 @@ public:
         mfo_clipboard(nullptr)
     {
     }
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SHARED);
 };
 
 #endif


### PR DESCRIPTION
1. Make SHARED subclass of juce::DeletedAtShutdown
2. Make SHARED also non-copyable and participat ein leak detection

Together these make it so that we don't have leaks on exit,
and we can see it. Closes #40