### PR TITLE
Don't return temporaries into a StringRef

### DIFF
--- a/Source/monique_ui_SliderConfig.h
+++ b/Source/monique_ui_SliderConfig.h
@@ -3340,7 +3340,11 @@ class BPMSlConfig : public ModulationSliderConfigBase
         }
         else
         {
-            return String(round01(bpm)) + String(" BPM");
+            // FIXME - this is unsatisfactory but keep the object around
+           // while considering #52
+            static String res;
+            res = String(round01(bpm)) + String(" BPM");
+            return res;
         }
     }
     StringRef get_bottom_button_switch_text() const noexcept override
@@ -6228,11 +6232,11 @@ class MorphSLConfig : public ModulationSliderConfigBase
         const float state = morhp_state->get_value();
         if( state <= 0.5 )
         {
-            return String("L");
+            return "L";
         }
         else
         {
-            return String("R");
+            return "R";
         }
     }
 


### PR DESCRIPTION
The pattern

StringRef foo() { return String( "bar" ); }

can result in the string being freed before the ref is resolved.
Address sanitizer shows this as a problem, as described in #52.
I'm not sure if this fix is the right one or if we should instead
change the API to String rather than StringRef, and especially
the dynamic string one is iffy, but this at least squashes the
memory problem the sanitizer showed in single instance.