### PR TITLE
Windows installer improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Calculate bitness
-math(EXPR MONIQUE_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
-message(STATUS "Targeting ${MONIQUE_BITNESS}-bit configuration")
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
+message(STATUS "Targeting ${BITS}-bit configuration")
 
 set(MONIQUE_JUCE_PATH "${CMAKE_SOURCE_DIR}/libs/JUCE" CACHE STRING "Path to JUCE library source tree")
 

--- a/resources/installer_win/monique32.iss
+++ b/resources/installer_win/monique32.iss
@@ -11,8 +11,8 @@
 [Setup]
 AppId={#MyID}
 AppName={#MyAppName}
+AppVerName={#MyAppName}
 AppVersion={#MONIQUE_VERSION}
-AppVerName={#MyAppName} {#MONIQUE_VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -23,13 +23,13 @@ DisableDirPage=yes
 DisableProgramGroupPage=yes
 AlwaysShowDirOnReadyPage=yes
 LicenseFile={#MONIQUE_SRC}\LICENSE-gpl3
-OutputBaseFilename={#MyAppName}-win32-{#MONIQUE_VERSION}-setup
+OutputBaseFilename={#MyAppName}-{#MONIQUE_VERSION}-Windows-32bit-setup
 SetupIconFile={#MONIQUE_SRC}\resources\installer_win\monique.ico
 UninstallDisplayIcon={uninstallexe}
 UsePreviousAppDir=yes
 Compression=lzma
 SolidCompression=yes
-UninstallFilesDir={autoappdata}\{#MyAppName}\uninstall
+UninstallFilesDir={app}\uninstall
 CloseApplicationsFilter=*.exe,*.vst3
 WizardStyle=modern
 WizardSizePercent=100
@@ -42,19 +42,22 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Types]
 Name: "full"; Description: "Full installation"
-Name: "plugin"; Description: "VST3 installation"
+Name: "vst3"; Description: "VST3 installation"
+;Name: "clap"; Description: "CLAP installation"
 Name: "standalone"; Description: "Standalone installation"
 Name: "custom"; Description: "Custom"; Flags: iscustom
 
 [Components]
-Name: "vst3"; Description: "{#MyAppNameCondensed} VST3 (32-bit)"; Types: full plugin custom
-Name: "exe"; Description: "{#MyAppNameCondensed} Standalone (32-bit)"; Types: full standalone custom
-Name: "docs"; Description: "{#MyAppNameCondensed} Manual"; Types: full plugin standalone custom
+Name: "VST3"; Description: "{#MyAppName} VST3 (32-bit)"; Types: full vst3 custom
+;Name: "CLAP"; Description: "{#MyAppName} CLAP (32-bit)"; Types: full clap custom
+Name: "SA"; Description: "{#MyAppName} Standalone (32-bit)"; Types: full standalone custom
+Name: "DOCS"; Description: "{#MyAppName} Manual"; Types: full vst3 standalone custom
 
 [Files]
-Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.exe"; DestDir: "{app}"; Components: exe; Flags: ignoreversion
-Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppName}.vst3\"; Components: vst3; Flags: ignoreversion recursesubdirs
-Source: "{#MONIQUE_SRC}\resources\manual\Manual-English.pdf"; DestDir: "{app}"; Components: docs; Flags: ignoreversion
+Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppPublisher}\{#MyAppName}.vst3\"; Components: VST3; Flags: ignoreversion recursesubdirs
+;Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.clap"; DestDir: "{autocf}\Clap\{#MyAppPublisher}\{#MyAppName}.clap"; Components: CLAP; Flags: ignoreversion
+Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.exe"; DestDir: "{app}"; Components: SA; Flags: ignoreversion
+Source: "{#MONIQUE_SRC}\resources\manual\Manual-English.pdf"; DestDir: "{app}"; Components: DOCS; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppName}.exe"; Flags: createonlyiffileexists

--- a/resources/installer_win/monique64.iss
+++ b/resources/installer_win/monique64.iss
@@ -13,8 +13,8 @@ ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
 AppId={#MyID}
 AppName={#MyAppName}
+AppVerName={#MyAppName}
 AppVersion={#MONIQUE_VERSION}
-AppVerName={#MyAppName} {#MONIQUE_VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -25,13 +25,13 @@ DisableDirPage=yes
 DisableProgramGroupPage=yes
 AlwaysShowDirOnReadyPage=yes
 LicenseFile={#MONIQUE_SRC}\LICENSE-gpl3
-OutputBaseFilename={#MyAppName}-win64-{#MONIQUE_VERSION}-setup
+OutputBaseFilename={#MyAppName}-{#MONIQUE_VERSION}-Windows-64bit-setup
 SetupIconFile={#MONIQUE_SRC}\resources\installer_win\monique.ico
 UninstallDisplayIcon={uninstallexe}
 UsePreviousAppDir=yes
 Compression=lzma
 SolidCompression=yes
-UninstallFilesDir={autoappdata}\{#MyAppName}\uninstall
+UninstallFilesDir={app}\uninstall
 CloseApplicationsFilter=*.exe,*.vst3
 WizardStyle=modern
 WizardSizePercent=100
@@ -44,19 +44,22 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Types]
 Name: "full"; Description: "Full installation"
-Name: "plugin"; Description: "VST3 installation"
+Name: "vst3"; Description: "VST3 installation"
+;Name: "clap"; Description: "CLAP installation"
 Name: "standalone"; Description: "Standalone installation"
 Name: "custom"; Description: "Custom"; Flags: iscustom
 
 [Components]
-Name: "vst3"; Description: "{#MyAppNameCondensed} VST3 (64-bit)"; Types: full plugin custom
-Name: "exe"; Description: "{#MyAppNameCondensed} Standalone (64-bit)"; Types: full standalone custom
-Name: "docs"; Description: "{#MyAppNameCondensed} Manual"; Types: full plugin standalone custom
+Name: "VST3"; Description: "{#MyAppName} VST3 (64-bit)"; Types: full vst3 custom
+;Name: "CLAP"; Description: "{#MyAppName} CLAP (64-bit)"; Types: full clap custom
+Name: "SA"; Description: "{#MyAppName} Standalone (64-bit)"; Types: full standalone custom
+Name: "DOCS"; Description: "{#MyAppName} Manual"; Types: full vst3 standalone custom
 
 [Files]
-Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.exe"; DestDir: "{app}"; Components: exe; Flags: ignoreversion
-Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppName}.vst3\"; Components: vst3; Flags: ignoreversion recursesubdirs
-Source: "{#MONIQUE_SRC}\resources\manual\Manual-English.pdf"; DestDir: "{app}"; Components: docs; Flags: ignoreversion
+Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppPublisher}\{#MyAppName}.vst3\"; Components: VST3; Flags: ignoreversion recursesubdirs
+;Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.clap"; DestDir: "{autocf}\Clap\{#MyAppPublisher}\{#MyAppName}.clap"; Components: CLAP; Flags: ignoreversion
+Source: "{#MONIQUE_BIN}\monique_products\{#MyAppName}.exe"; DestDir: "{app}"; Components: SA; Flags: ignoreversion
+Source: "{#MONIQUE_SRC}\resources\manual\Manual-English.pdf"; DestDir: "{app}"; Components: DOCS; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppName}.exe"; Flags: createonlyiffileexists


### PR DESCRIPTION
- Add CLAP component but hide it until we implement CLAP
- Create MONIQUE_PRODUCT_DIR in monique-staged like we do in other installers
(and so we can implement windows cleanup stage)
- Add windows cleanup stage
- Add bitness to windows zip installer
- Clear up language for NUGET search
(we don't actually create installer at this stage)
- Fix bitness check to match other products
- Fix installer exe name to match zip installer
- Fix AppVerName to match Surge installer
- Better uninstaller location
- Make sure we install in publisher folders with Surge